### PR TITLE
changed introspection of collection to determine class

### DIFF
--- a/lib/activeadmin-poro-decorator.rb
+++ b/lib/activeadmin-poro-decorator.rb
@@ -18,7 +18,7 @@ module ActiveadminPoroDecorator
     def decorate(*args)
       collection_or_object = args[0]
       if collection_or_object.respond_to?(:to_ary)
-        class_name = collection_or_object.class.to_s.demodulize.gsub('ActiveRecord_Relation_', '')
+        class_name = collection_or_object.class.to_s.deconstantize
         DecoratedEnumerableProxy.new(collection_or_object, class_name)
       else
         new(collection_or_object)


### PR DESCRIPTION
When I tried using your gem as-is this line crapped out, returning 'ActiveRecord_Relation' for something like 'MyFoo::ActiveRecordRelation'. This change returns 'MyFoo' instead (nb havent tested this with anything other than top-level classes)
